### PR TITLE
fix(Combat): 무기 충돌 활성화 시 NULL 참조 오류 방지

### DIFF
--- a/Source/Ashen_Cathedral/Private/Components/Combat/PawnCombatComponent.cpp
+++ b/Source/Ashen_Cathedral/Private/Components/Combat/PawnCombatComponent.cpp
@@ -127,7 +127,10 @@ void UPawnCombatComponent::ToggleWeaponCollision(bool bShouldEnable, EToggleDama
 	{
 		const AACWeaponBase* WeaponToToggle = GetCharacterCurrentEquippedWeapon();
 
-		check(WeaponToToggle);
+		if (!WeaponToToggle)
+		{
+			return;
+		}
 
 		WeaponToToggle->GetWeaponCollisionBox()->SetCollisionEnabled(bShouldEnable ? ECollisionEnabled::QueryOnly : ECollisionEnabled::NoCollision);
 
@@ -144,7 +147,10 @@ void UPawnCombatComponent::HandleToggleCollision(bool bShouldEnable, EToggleDama
 	{
 		const AACWeaponBase* WeaponToToggle = GetCharacterCurrentEquippedWeapon();
 
-		check(WeaponToToggle);
+		if (!WeaponToToggle)
+		{
+			return;
+		}
 
 		WeaponToToggle->GetWeaponCollisionBox()->SetCollisionEnabled(bShouldEnable ? ECollisionEnabled::QueryOnly : ECollisionEnabled::NoCollision);
 


### PR DESCRIPTION
## 📌 PR 목적
무기 충돌 활성화 시 발생할 수 있는 NULL 참조 오류를 방지하기 위한 수정

## 🛠 변경 사항
- `ToggleWeaponCollision` 호출 중 `WeaponToToggle`이 NULL일 경우 강제 종료 처리 추가
- 불필요한 `check` 호출 제거로 안정성 개선

## 🔍 확인 방법
- 무기 충돌 활성화 여부를 테스트하며 오류가 발생하지 않는지 확인

## ✅ 체크리스트
- [x] 코드 컴파일 및 빌드 성공
- [x] 기존 기능 동작 확인
- [x] 주석 최소화 확인
- [x] 코드 컨벤션 준수 확인

## #️⃣연관된 이슈
> None